### PR TITLE
Simplify config flow UI text

### DIFF
--- a/custom_components/lightener/translations/de.json
+++ b/custom_components/lightener/translations/de.json
@@ -24,7 +24,7 @@
           "brightness": "Helligkeitskurve"
         },
         "data_description": {
-          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass diese Lampe bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
+          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass \"{light_name}\" bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
         }
       }
     },
@@ -48,7 +48,7 @@
           "brightness": "Helligkeitskurve"
         },
         "data_description": {
-          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass diese Lampe bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
+          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass \"{light_name}\" bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
         }
       }
     },

--- a/custom_components/lightener/translations/de.json
+++ b/custom_components/lightener/translations/de.json
@@ -1,0 +1,60 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Neues Lightener-Ger\u00e4t",
+        "description": "",
+        "data": {
+          "name": "Name"
+        },
+        "data_description": {
+          "name": "Am besten ein Raum- oder Bereichsname, z.\u00a0B. \"Wohnzimmer\""
+        }
+      },
+      "lights": {
+        "title": "Lampen ausw\u00e4hlen",
+        "data": {
+          "controlled_entities": "Zu steuernde Lampen"
+        }
+      },
+      "light_configuration": {
+        "title": "Helligkeitskurve \"{light_name}\"",
+        "description": "Aktuell: {current_brightness}",
+        "data": {
+          "brightness": "Helligkeitskurve"
+        },
+        "data_description": {
+          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass diese Lampe bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
+        }
+      }
+    },
+    "error": {
+      "controlled_entities_empty": "Mindestens eine Lampe ausw\u00e4hlen",
+      "invalid_brightness": "Ung\u00fcltiger Eintrag \"{error_entry}\". Format \"X:Y\" verwenden, wobei X 1\u2013100 und Y 0\u2013100 ist, z.\u00a0B. \"40:100\""
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Lampen ausw\u00e4hlen",
+        "data": {
+          "controlled_entities": "Zu steuernde Lampen"
+        }
+      },
+      "light_configuration": {
+        "title": "Helligkeitskurve \"{light_name}\"",
+        "description": "Aktuell: {current_brightness}",
+        "data": {
+          "brightness": "Helligkeitskurve"
+        },
+        "data_description": {
+          "brightness": "Eine Zuordnung pro Zeile als Gruppe:Lampe. Beispiel: \"60:100\" bedeutet, dass diese Lampe bei 60\u00a0% Gruppenhelligkeit 100\u00a0% erreicht."
+        }
+      }
+    },
+    "error": {
+      "controlled_entities_empty": "Mindestens eine Lampe ausw\u00e4hlen",
+      "invalid_brightness": "Ung\u00fcltiger Eintrag \"{error_entry}\". Format \"X:Y\" verwenden, wobei X 1\u2013100 und Y 0\u2013100 ist, z.\u00a0B. \"40:100\""
+    }
+  }
+}

--- a/custom_components/lightener/translations/en.json
+++ b/custom_components/lightener/translations/en.json
@@ -24,7 +24,7 @@
           "brightness": "Brightness curve"
         },
         "data_description": {
-          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, this light reaches 100%."
+          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, \"{light_name}\" reaches 100%."
         }
       }
     },
@@ -48,7 +48,7 @@
           "brightness": "Brightness curve"
         },
         "data_description": {
-          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, this light reaches 100%."
+          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, \"{light_name}\" reaches 100%."
         }
       }
     },

--- a/custom_components/lightener/translations/en.json
+++ b/custom_components/lightener/translations/en.json
@@ -2,59 +2,59 @@
   "config": {
     "step": {
       "user": {
-        "title": "Create a Lightener device",
-        "description": "Please provide a name for the Lightener device you are creating",
+        "title": "New Lightener device",
+        "description": "",
         "data": {
-          "name": "Device name"
+          "name": "Name"
         },
         "data_description": {
-          "name": "The purpose is to clearly indicate which group of lights is controlled by this device. Typically, it is an area or room name, such as \"Living Room,\" but it can be anything"
+          "name": "A room or area name works best, e.g. \"Living Room\""
         }
       },
       "lights": {
-        "title": "Controlled lights",
+        "title": "Select lights",
         "data": {
-          "controlled_entities": "Select the light entities to be controlled by this Lightener device"
+          "controlled_entities": "Lights to control"
         }
       },
       "light_configuration": {
-        "title": "Configure \"{light_name}\"",
-        "description": "Current brightness: {current_brightness}",
+        "title": "\"{light_name}\" brightness curve",
+        "description": "Currently: {current_brightness}",
         "data": {
-          "brightness": "Brightness mapping"
+          "brightness": "Brightness curve"
         },
         "data_description": {
-          "brightness": "A list that maps the brightness of this light when the Lightener reaches certain brightness levels. Each line has the format (Lightener brightness %): (Controlled light brightness %). For example, \"60:100\" specifies that when the Lightener reaches 60% brightness, \"{light_name}\" will reach 100% brightness"
+          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, this light reaches 100%."
         }
       }
     },
     "error": {
       "controlled_entities_empty": "Select at least one light",
-      "invalid_brightness": "Invalid brightness mapping configuration \"{error_entry}\". Each line must have the format \"(number from 1 to 100): (number from 0 to 100)\". For example, \"40:100\""
+      "invalid_brightness": "Invalid entry \"{error_entry}\". Use the format \"X:Y\" where X is 1\u2013100 and Y is 0\u2013100, e.g. \"40:100\""
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Controlled lights",
+        "title": "Select lights",
         "data": {
-          "controlled_entities": "Select the light entities to be controlled by this Lightener device"
+          "controlled_entities": "Lights to control"
         }
       },
       "light_configuration": {
-        "title": "Configure \"{light_name}\"",
-        "description": "Current brightness: {current_brightness}",
+        "title": "\"{light_name}\" brightness curve",
+        "description": "Currently: {current_brightness}",
         "data": {
-          "brightness": "Brightness mapping"
+          "brightness": "Brightness curve"
         },
         "data_description": {
-          "brightness": "A list that maps the brightness of this light when the Lightener reaches certain brightness levels. Each line has the format (Lightener brightness %): (Controlled light brightness %). For example, \"60:100\" specifies that when the Lightener reaches 60% brightness, \"{light_name}\" will reach 100% brightness"
+          "brightness": "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, this light reaches 100%."
         }
       }
     },
     "error": {
       "controlled_entities_empty": "Select at least one light",
-      "invalid_brightness": "Invalid brightness mapping configuration \"{error_entry}\". Each line must have the format \"(number from 1 to 100): (number from 0 to 100)\". For example, \"40:100\""
+      "invalid_brightness": "Invalid entry \"{error_entry}\". Use the format \"X:Y\" where X is 1\u2013100 and Y is 0\u2013100, e.g. \"40:100\""
     }
   }
 }

--- a/custom_components/lightener/translations/pt-BR.json
+++ b/custom_components/lightener/translations/pt-BR.json
@@ -24,7 +24,7 @@
           "brightness": "Curva de brilho"
         },
         "data_description": {
-          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, esta luz atinge 100%."
+          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, \"{light_name}\" atinge 100%."
         }
       }
     },
@@ -48,7 +48,7 @@
           "brightness": "Curva de brilho"
         },
         "data_description": {
-          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, esta luz atinge 100%."
+          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, \"{light_name}\" atinge 100%."
         }
       }
     },

--- a/custom_components/lightener/translations/pt-BR.json
+++ b/custom_components/lightener/translations/pt-BR.json
@@ -2,59 +2,59 @@
   "config": {
     "step": {
       "user": {
-        "title": "Criar um dispositivo Lightener",
-        "description": "Por favor, forneça um nome para o dispositivo Lightener que você está criando",
+        "title": "Novo dispositivo Lightener",
+        "description": "",
         "data": {
-          "name": "Nome do dispositivo"
+          "name": "Nome"
         },
         "data_description": {
-          "name": "O objetivo é indicar claramente qual grupo de luzes é controlado por este dispositivo. Normalmente, é o nome de uma área ou cômodo, como \"Sala de Estar\", mas pode ser qualquer coisa."
+          "name": "Um nome de c\u00f4modo ou \u00e1rea funciona melhor, ex. \"Sala de Estar\""
         }
       },
       "lights": {
-        "title": "Luzes controladas",
+        "title": "Selecionar luzes",
         "data": {
-          "controlled_entities": "Selecione as entidades de luz a serem controladas por este dispositivo Lightener"
+          "controlled_entities": "Luzes a controlar"
         }
       },
       "light_configuration": {
-        "title": "Configurar \"{light_name}\"",
-        "description": "Brilho atual: {current_brightness}",
+        "title": "Curva de brilho de \"{light_name}\"",
+        "description": "Atualmente: {current_brightness}",
         "data": {
-          "brightness": "Mapeamento de brilho"
+          "brightness": "Curva de brilho"
         },
         "data_description": {
-          "brightness": "Uma lista que mapeia o brilho desta luz quando o Lightener atinge determinados níveis de brilho. Cada linha tem o formato (Brilho do Lightener %): (Brilho da luz controlada %). Por exemplo, \"60:100\" especifica que quando o Lightener atinge 60% de brilho, \"{light_name}\" atingirá 100% de brilho"
+          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, esta luz atinge 100%."
         }
       }
     },
     "error": {
       "controlled_entities_empty": "Selecione pelo menos uma luz",
-      "invalid_brightness": "Configuração de mapeamento de brilho inválida \"{error_entry}\". Cada linha deve ter o formato \"(número de 1 a 100): (número de 0 a 100)\". Por exemplo, \"40:100\""
+      "invalid_brightness": "Entrada inv\u00e1lida \"{error_entry}\". Use o formato \"X:Y\" onde X \u00e9 1\u2013100 e Y \u00e9 0\u2013100, ex. \"40:100\""
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Luzes controladas",
+        "title": "Selecionar luzes",
         "data": {
-          "controlled_entities": "Selecione as entidades de luz a serem controladas por este dispositivo Lightener"
+          "controlled_entities": "Luzes a controlar"
         }
       },
       "light_configuration": {
-        "title": "Configurar \"{light_name}\"",
-        "description": "Brilho atual: {current_brightness}",
+        "title": "Curva de brilho de \"{light_name}\"",
+        "description": "Atualmente: {current_brightness}",
         "data": {
-          "brightness": "Mapeamento de brilho"
+          "brightness": "Curva de brilho"
         },
         "data_description": {
-          "brightness": "Uma lista que mapeia o brilho desta luz quando o Lightener atinge determinados níveis de brilho. Cada linha tem o formato (Brilho do Lightener %): (Brilho da luz controlada %). Por exemplo, \"60:100\" especifica que quando o Lightener atinge 60% de brilho, \"{light_name}\" atingirá 100% de brilho."
+          "brightness": "Um mapeamento por linha como grupo:luz. Exemplo: \"60:100\" significa que a 60% de brilho do grupo, esta luz atinge 100%."
         }
       }
     },
     "error": {
       "controlled_entities_empty": "Selecione pelo menos uma luz",
-      "invalid_brightness": "Configuração de mapeamento de brilho inválida \"{error_entry}\". Cada linha deve ter o formato \"(número de 1 a 100): (número de 0 a 100)\". Por exemplo, \"40:100\""
+      "invalid_brightness": "Entrada inv\u00e1lida \"{error_entry}\". Use o formato \"X:Y\" onde X \u00e9 1\u2013100 e Y \u00e9 0\u2013100, ex. \"40:100\""
     }
   }
 }

--- a/custom_components/lightener/translations/sk.json
+++ b/custom_components/lightener/translations/sk.json
@@ -24,7 +24,7 @@
           "brightness": "Krivka jasu"
         },
         "data_description": {
-          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny toto svetlo dosiahne 100%."
+          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny \"{light_name}\" dosiahne 100%."
         }
       }
     },
@@ -48,7 +48,7 @@
           "brightness": "Krivka jasu"
         },
         "data_description": {
-          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny toto svetlo dosiahne 100%."
+          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny \"{light_name}\" dosiahne 100%."
         }
       }
     },

--- a/custom_components/lightener/translations/sk.json
+++ b/custom_components/lightener/translations/sk.json
@@ -2,59 +2,59 @@
   "config": {
     "step": {
       "user": {
-        "title": "Vytvorte zariadenie Lightener",
-        "description": "Zadajte názov zariadenia Lightener, ktoré vytvárate",
+        "title": "Nov\u00e9 zariadenie Lightener",
+        "description": "",
         "data": {
-          "name": "Názov zariadenia"
+          "name": "N\u00e1zov"
         },
         "data_description": {
-          "name": "Účelom je jasne uviesť, ktorá skupina svetiel je týmto zariadením ovládaná. Zvyčajne je to názov oblasti alebo miestnosti, napríklad \"Obývačka\", ale môže to byť čokoľvek"
+          "name": "Najlep\u0161ie funguje n\u00e1zov miestnosti alebo oblasti, napr. \"Ob\u00fdva\u010dka\""
         }
       },
       "lights": {
-        "title": "Ovládané svetlá",
+        "title": "Vybra\u0165 svetl\u00e1",
         "data": {
-          "controlled_entities": "Vyberte svetelné entity, ktoré chcete ovládať týmto zariadením Lightener"
+          "controlled_entities": "Svetl\u00e1 na ovl\u00e1danie"
         }
       },
       "light_configuration": {
-        "title": "Konfigurovať \"{light_name}\"",
-        "description": "Current brightness: {current_brightness}",
+        "title": "Krivka jasu \"{light_name}\"",
+        "description": "Aktu\u00e1lne: {current_brightness}",
         "data": {
-          "brightness": "Mapovanie jasu"
+          "brightness": "Krivka jasu"
         },
         "data_description": {
-          "brightness": "Zoznam, ktorý mapuje jas tohto svetla, keď Lightener dosiahne určité úrovne jasu. Každý riadok má formát (Lightener jas %): (Kontrolovaný jas svetla %). Napríklad, \"60:100\" určuje, keď Lightener dosiahne jas 60 %, \"{light_name}\" dosiahne 100% jas"
+          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny toto svetlo dosiahne 100%."
         }
       }
     },
     "error": {
-      "controlled_entities_empty": "Vyberte aspoň jedno svetlo",
-      "invalid_brightness": "Neplatná konfigurácia mapovania jasu \"{error_entry}\". Každý riadok musí mať formát \"(číslo od 1 do 100): (číslo od 0 do 100)\". Napríklad, \"40:100\""
+      "controlled_entities_empty": "Vyberte aspo\u0148 jedno svetlo",
+      "invalid_brightness": "Neplatn\u00fd z\u00e1znam \"{error_entry}\". Pou\u017eite form\u00e1t \"X:Y\" kde X je 1\u2013100 a Y je 0\u2013100, napr. \"40:100\""
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Ovládané svetlá",
+        "title": "Vybra\u0165 svetl\u00e1",
         "data": {
-          "controlled_entities": "Vyberte svetelné entity, ktoré chcete ovládať týmto zariadením Lightener"
+          "controlled_entities": "Svetl\u00e1 na ovl\u00e1danie"
         }
       },
       "light_configuration": {
-        "title": "Konfigurovať \"{light_name}\"",
-        "description": "Current brightness: {current_brightness}",
+        "title": "Krivka jasu \"{light_name}\"",
+        "description": "Aktu\u00e1lne: {current_brightness}",
         "data": {
-          "brightness": "Mapovanie jasu"
+          "brightness": "Krivka jasu"
         },
         "data_description": {
-          "brightness": "Zoznam, ktorý mapuje jas tohto svetla, keď Lightener dosiahne určité úrovne jasu. Každý riadok má formát (Jas Lightener %): (Kontrolovaný jas svetla %). Napríklad, \"60:100\" určuje, že keď Lightener dosiahne jas 60 %, \"{light_name}\" dosiahne 100% jas"
+          "brightness": "Jedno mapovanie na riadok ako skupina:svetlo. Pr\u00edklad: \"60:100\" znamen\u00e1, \u017ee pri 60% jasu skupiny toto svetlo dosiahne 100%."
         }
       }
     },
     "error": {
-      "controlled_entities_empty": "Vyberte aspoň jedno svetlo",
-      "invalid_brightness": "Neplatná konfigurácia mapovania jasu \"{error_entry}\". Každý riadok musí mať formát \"(číslo od 1 do 100): (číslo od 0 do 100)\". Napríklad, \"40:100\""
+      "controlled_entities_empty": "Vyberte aspo\u0148 jedno svetlo",
+      "invalid_brightness": "Neplatn\u00fd z\u00e1znam \"{error_entry}\". Pou\u017eite form\u00e1t \"X:Y\" kde X je 1\u2013100 a Y je 0\u2013100, napr. \"40:100\""
     }
   }
 }


### PR DESCRIPTION
## Summary

Rewrites the config flow UI text across all 3 translation files (en, pt-BR, sk) to be concise and scannable:

- **Shorter labels**: "Device name" → "Name", "Controlled lights" → "Select lights", "Brightness mapping" → "Brightness curve"
- **Trimmed descriptions**: Verbose paragraph-length helper text replaced with one-line tooltips
- **Removed filler**: "Please provide a name for the Lightener device you are creating" → field label speaks for itself
- **Fixed Slovak**: Untranslated English string "Current brightness" now properly translated

### Before vs After (English)

| Element | Before | After |
|---------|--------|-------|
| Step 1 title | "Create a Lightener device" | "New Lightener device" |
| Name hint | 40-word paragraph | "A room or area name works best, e.g. \"Living Room\"" |
| Light selector label | "Select the light entities to be controlled by this Lightener device" | "Lights to control" |
| Mapping helper | 50-word paragraph | "One mapping per line as group:light. Example: \"60:100\" means at 60% group brightness, this light reaches 100%." |

No Python changes — purely translation/copy improvements.

## Context

This is a low-risk incremental step toward the broader UX improvements discussed in #147 and #117. While those issues call for structural changes (visual curve editor, single-screen config), this PR reduces cognitive load in the existing flow by cleaning up the copy.

## Notes

- pt-BR and sk translations are best-effort — native speaker review welcome
- All placeholder variables (`{light_name}`, `{current_brightness}`, `{error_entry}`) preserved
- JSON structure unchanged; no config_flow.py modifications

## Test plan

- [ ] Install integration, run config flow — verify all 3 steps render correctly
- [ ] Edit an existing Lightener device via options flow — verify labels match
- [ ] Trigger validation error on brightness mapping — verify error message renders with `{error_entry}` placeholder
- [ ] Switch HA language to pt-BR and sk — verify translations render

🤖 Generated with [Claude Code](https://claude.com/claude-code)